### PR TITLE
chore(dependabot): add 4-day cooldown, exempt Docker from cooldown -- Review and Merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
     groups:
       pub:
         patterns: ["*"]
+    cooldown:
+      default-days: 4


### PR DESCRIPTION
## Dependabot 4-day cooldown rollout

This PR is part of an org-wide rollout adding a JFrog Curation-aligned Dependabot cooldown policy:
- `docker`, `docker-compose`, `devcontainers` ecosystems: cooldown disabled entirely (`cooldown: { exclude: ["*"] }`) since these images don't route through Curation.
- `github-actions`: left untouched (no cooldown added if none existed; existing cooldown blocks preserved as-is).
- All other ecosystems: `cooldown.default-days` raised to a floor of 4 (existing values `>= 4` were left untouched; nothing was silently lowered).

Config file: `.github/dependabot.yml`

### Diff
```diff
diff --git a/.github/dependabot.yml b/.github/dependabot.yml
index d9a8ae1..434584c 100644
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,6 @@ updates:
       interval: weekly
     groups:
       pub:
-        patterns: ["*"]
\ No newline at end of file
+        patterns: ["*"]
+    cooldown:
+      default-days: 4
\ No newline at end of file
```

Automated change — please review and merge.