### PR TITLE
FEDX-6777: Re-enable format check in CI and apply Dart 3 format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
     uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.14
     with:
       sdk: 3.12.2
-      format-check: false
 
   build:
     uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Added support for `enclosing_range` on occurrences definitions
 - Upgraded to Dart 3.12.2
+- Formatted with Dart 3.12.2
 
 ## 1.6.2
 - Fixed a few minor bugs found in pubspec.yaml indexing (skips publish_to: none pubspecs, and considers "version" optional)

--- a/bin/scip_dart.dart
+++ b/bin/scip_dart.dart
@@ -11,46 +11,48 @@ import 'package:scip_dart/src/pubspec_indexer.dart';
 import 'package:scip_dart/src/version.dart';
 
 Future<void> main(List<String> args) async {
-  final result = (ArgParser()
-        ..addOption(
-          'output',
-          abbr: 'o',
-          defaultsTo: 'index.scip',
-          help:
-              'The output file to write the index to. Use "-" to write to stdout',
-        )
-        ..addFlag(
-          'index-pubspec',
-          defaultsTo: false,
-          help: 'Whether or not to index the pubspec.yaml file',
-        )
-        ..addFlag(
-          'performance',
-          aliases: ['perf'],
-          defaultsTo: false,
-          help: 'Whether or not to output performance metrics during indexing',
-        )
-        ..addFlag(
-          'verbose',
-          abbr: 'v',
-          defaultsTo: false,
-          help: 'Whether or not to display debugging text during indexing',
-        )
-        ..addFlag(
-          'version',
-          defaultsTo: false,
-          help: 'Display the current version of scip-dart',
-        )
-        ..addFlag(
-          'index-relationships',
-          help: 'DEPRECATED, has no effect on executed code',
-        )
-        ..addMultiOption(
-          'path',
-          abbr: 'p',
-          help: 'DEPRECATED, has no effect on executed code',
-        ))
-      .parse(args);
+  final result =
+      (ArgParser()
+            ..addOption(
+              'output',
+              abbr: 'o',
+              defaultsTo: 'index.scip',
+              help:
+                  'The output file to write the index to. Use "-" to write to stdout',
+            )
+            ..addFlag(
+              'index-pubspec',
+              defaultsTo: false,
+              help: 'Whether or not to index the pubspec.yaml file',
+            )
+            ..addFlag(
+              'performance',
+              aliases: ['perf'],
+              defaultsTo: false,
+              help:
+                  'Whether or not to output performance metrics during indexing',
+            )
+            ..addFlag(
+              'verbose',
+              abbr: 'v',
+              defaultsTo: false,
+              help: 'Whether or not to display debugging text during indexing',
+            )
+            ..addFlag(
+              'version',
+              defaultsTo: false,
+              help: 'Display the current version of scip-dart',
+            )
+            ..addFlag(
+              'index-relationships',
+              help: 'DEPRECATED, has no effect on executed code',
+            )
+            ..addMultiOption(
+              'path',
+              abbr: 'p',
+              help: 'DEPRECATED, has no effect on executed code',
+            ))
+          .parse(args);
 
   if (result['version'] as bool) {
     print(scipDartVersion);
@@ -67,8 +69,9 @@ Future<void> main(List<String> args) async {
     );
   }
 
-  final packageRoot =
-      result.rest.isNotEmpty ? result.rest.first : Directory.current.path;
+  final packageRoot = result.rest.isNotEmpty
+      ? result.rest.first
+      : Directory.current.path;
 
   final packageConfig = await findPackageConfig(Directory(packageRoot));
   if (packageConfig == null) {
@@ -90,16 +93,19 @@ Future<void> main(List<String> args) async {
     final pubspecLockFile = File(p.join(packageRoot, 'pubspec.lock'));
     if (!pubspecLockFile.existsSync()) {
       stderr.writeln(
-          'ERROR: Unable to locate pubspec.lock. Have you ran pub get?');
+        'ERROR: Unable to locate pubspec.lock. Have you ran pub get?',
+      );
       exit(1);
     }
     final pubspecLock = PubspecLock.parse(pubspecLockFile.readAsStringSync());
 
-    index.documents.add(indexPubspec(
-      pubspec: pubspec,
-      pubspecStr: pubspecStr,
-      pubspecLock: pubspecLock,
-    ));
+    index.documents.add(
+      indexPubspec(
+        pubspec: pubspec,
+        pubspecStr: pubspecStr,
+        pubspecLock: pubspecLock,
+      ),
+    );
   }
 
   if (result['output'] as String == '-') {

--- a/lib/src/indexer.dart
+++ b/lib/src/indexer.dart
@@ -31,21 +31,18 @@ Future<Index> indexPackage(
       .map((package) => p.normalize(package.packageUriRoot.toFilePath()))
       .toList();
 
-  final nestedPackages = (await pubspecPathsFor(root))
-      .map((path) => p.dirname(path))
-      .where((path) => path != root)
-      .toList();
+  final nestedPackages = (await pubspecPathsFor(
+    root,
+  )).map((path) => p.dirname(path)).where((path) => path != root).toList();
 
   if (Flags.instance.verbose) print('Ignoring subdirectories: $nestedPackages');
 
   final collection = AnalysisContextCollection(
-      includedPaths: [
-        ...allPackageRoots,
-        dirPath,
-      ],
-      // only index dart files of the current dart package, to index nested
-      // packages, scip indexing can simply be re-run for that nested package
-      excludedPaths: nestedPackages);
+    includedPaths: [...allPackageRoots, dirPath],
+    // only index dart files of the current dart package, to index nested
+    // packages, scip indexing can simply be re-run for that nested package
+    excludedPaths: nestedPackages,
+  );
 
   if (Flags.instance.performance) print('Analyzing Source');
   final st = Stopwatch()..start();
@@ -64,8 +61,9 @@ Future<Index> indexPackage(
     print('Parsing Ast');
   }
 
-  final documents =
-      resolvedUnits.whereType<ResolvedUnitResult>().map((resUnit) {
+  final documents = resolvedUnits.whereType<ResolvedUnitResult>().map((
+    resUnit,
+  ) {
     final relativePath = p.relative(resUnit.path, from: dirPath);
 
     final visitor = ScipVisitor(

--- a/lib/src/metadata.dart
+++ b/lib/src/metadata.dart
@@ -58,15 +58,18 @@ SymbolMetadata getSymbolMetadata(
 
   final diagnostics = analysisErrors
       .where((error) => error.offset == offset)
-      .map((error) => proto.Diagnostic(
-              code: error.errorCode.name,
-              message: error.message,
-              severity: error.severity.toProto(),
-              tags: [
-                if (element.hasDeprecated) proto.DiagnosticTag.Deprecated,
-                if (_unusedHintCodes.contains(error.errorCode.uniqueName))
-                  proto.DiagnosticTag.Unnecessary,
-              ]))
+      .map(
+        (error) => proto.Diagnostic(
+          code: error.errorCode.name,
+          message: error.message,
+          severity: error.severity.toProto(),
+          tags: [
+            if (element.hasDeprecated) proto.DiagnosticTag.Deprecated,
+            if (_unusedHintCodes.contains(error.errorCode.uniqueName))
+              proto.DiagnosticTag.Unnecessary,
+          ],
+        ),
+      )
       .toList();
 
   return SymbolMetadata(

--- a/lib/src/pubspec_indexer.dart
+++ b/lib/src/pubspec_indexer.dart
@@ -34,11 +34,13 @@ Document indexPubspec({
   if (pubspec.publishTo != 'none') {
     final info = _buildFileSymbol(pubspec);
     symbols.add(info);
-    occurrences.add(Occurrence(
-      symbol: info.symbol,
-      symbolRoles: SymbolRole.Definition.value,
-      range: [0, 0, 0],
-    ));
+    occurrences.add(
+      Occurrence(
+        symbol: info.symbol,
+        symbolRoles: SymbolRole.Definition.value,
+        range: [0, 0, 0],
+      ),
+    );
   }
 
   final deps = {
@@ -50,10 +52,12 @@ Document indexPubspec({
     for (final dep in deps[kind]!.entries) {
       final info = _buildSymbol(dep.key, pubspecLock);
       symbols.add(info);
-      occurrences.add(Occurrence(
-        symbol: info.symbol,
-        range: pubspecLineInfo.getDependencyRange(pubspecStr, dep.key, kind),
-      ));
+      occurrences.add(
+        Occurrence(
+          symbol: info.symbol,
+          range: pubspecLineInfo.getDependencyRange(pubspecStr, dep.key, kind),
+        ),
+      );
     }
   }
 
@@ -80,10 +84,7 @@ SymbolInformation _buildFileSymbol(Pubspec pubspec) {
         .UnspecifiedKind, // TODO: Add SymbolInformation_Kind.Dependency
     signatureDocumentation: Document(
       language: Language.YAML.name,
-      text: [
-        'name: ${pubspec.name}',
-        'version: ${pubspec.version}',
-      ].join('\n'),
+      text: ['name: ${pubspec.name}', 'version: ${pubspec.version}'].join('\n'),
     ),
   );
 }
@@ -92,7 +93,8 @@ SymbolInformation _buildSymbol(String depName, PubspecLock lock) {
   final depVersion = lock.packages[depName]?.version.toString();
   if (depVersion == null) {
     throw Exception(
-        'Unable to find ${depName} in pubspec.lock. Have you ran pub get?');
+      'Unable to find ${depName} in pubspec.lock. Have you ran pub get?',
+    );
   }
 
   final symbol = [
@@ -110,10 +112,7 @@ SymbolInformation _buildSymbol(String depName, PubspecLock lock) {
         .UnspecifiedKind, // TODO: Add SymbolInformation_Kind.Dependency and SymbolInformation_Kind.DevDependency
     signatureDocumentation: Document(
       language: Language.YAML.name,
-      text: [
-        'name: $depName',
-        'version: $depVersion',
-      ].join('\n'),
+      text: ['name: $depName', 'version: $depVersion'].join('\n'),
     ),
   );
 }
@@ -129,12 +128,18 @@ enum DependencyKind {
 
 extension _PubspecLineInfo on LineInfo {
   List<int> getDependencyRange(
-      String pubspecStr, String name, DependencyKind kind) {
-    final section =
-        getYamlSection(pubspecStr, RegExp(kind.matcher, multiLine: true));
+    String pubspecStr,
+    String name,
+    DependencyKind kind,
+  ) {
+    final section = getYamlSection(
+      pubspecStr,
+      RegExp(kind.matcher, multiLine: true),
+    );
     if (section == null) {
       throw Exception(
-          'Unable to find section "${kind.matcher}" in pubspec.yaml');
+        'Unable to find section "${kind.matcher}" in pubspec.yaml',
+      );
     }
     final sectionStart = pubspecStr.indexOf(section);
     final depStart = section.indexOf('  ${name}:') + 2;

--- a/lib/src/relationship_generator.dart
+++ b/lib/src/relationship_generator.dart
@@ -18,10 +18,12 @@ List<Relationship>? relationshipsFor(
 
     return element.allSupertypes
         .where((type) => !type.isDartCoreObject)
-        .map((type) => Relationship(
-              symbol: symbolGenerator.symbolFor(type.element),
-              isImplementation: true,
-            ))
+        .map(
+          (type) => Relationship(
+            symbol: symbolGenerator.symbolFor(type.element),
+            isImplementation: true,
+          ),
+        )
         .toList();
   }
 
@@ -58,10 +60,13 @@ List<Relationship>? relationshipsFor(
     }
 
     return referencingElements
-        .map((type) => Relationship(
+        .map(
+          (type) => Relationship(
             symbol: symbolGenerator.symbolFor(type),
             isImplementation: true,
-            isReference: true))
+            isReference: true,
+          ),
+        )
         .toList();
   }
 

--- a/lib/src/scip_visitor.dart
+++ b/lib/src/scip_visitor.dart
@@ -32,17 +32,16 @@ class ScipVisitor extends GeneralizingAstVisitor {
     this._analysisErrors,
     PackageConfig packageConfig,
     Pubspec pubspec,
-  ) : _symbolGenerator = SymbolGenerator(
-          packageConfig,
-          pubspec,
-        ) {
+  ) : _symbolGenerator = SymbolGenerator(packageConfig, pubspec) {
     final fileSymbol = _symbolGenerator.fileSymbolFor(_relativePath);
-    occurrences.add(Occurrence(
-      symbol: fileSymbol,
-      range: [0, 0, 0],
-      syntaxKind: SyntaxKind.IdentifierModule,
-      symbolRoles: SymbolRole.Definition.value,
-    ));
+    occurrences.add(
+      Occurrence(
+        symbol: fileSymbol,
+        range: [0, 0, 0],
+        syntaxKind: SyntaxKind.IdentifierModule,
+        symbolRoles: SymbolRole.Definition.value,
+      ),
+    );
     symbols.add(SymbolInformation(symbol: fileSymbol));
   }
 
@@ -68,11 +67,7 @@ class ScipVisitor extends GeneralizingAstVisitor {
 
     final relationships = relationshipsFor(node, element, _symbolGenerator);
 
-    _registerAsDefinition(
-      element,
-      node,
-      relationships: relationships,
-    );
+    _registerAsDefinition(element, node, relationships: relationships);
   }
 
   void _visitNormalFormalParameter(NormalFormalParameter node) {
@@ -131,23 +126,27 @@ class ScipVisitor extends GeneralizingAstVisitor {
     final symbol = _symbolGenerator.symbolFor(element);
     if (symbol != null) {
       final meta = getSymbolMetadata(element, offset, _analysisErrors);
-      occurrences.add(Occurrence(
-        range: _lineInfo.getRange(offset, length),
-        symbol: symbol,
-        diagnostics: meta.diagnostics,
-      ));
+      occurrences.add(
+        Occurrence(
+          range: _lineInfo.getRange(offset, length),
+          symbol: symbol,
+          diagnostics: meta.diagnostics,
+        ),
+      );
 
       if (!element.source!.fullName.startsWith(_projectRoot)) {
         if (!globalExternalSymbols.any(
           (symbolInfo) => symbolInfo.symbol == symbol,
         )) {
           final meta = getSymbolMetadata(element, offset, _analysisErrors);
-          globalExternalSymbols.add(SymbolInformation(
-            symbol: symbol,
-            documentation: meta.documentation,
-            signatureDocumentation: meta.signatureDocumentation,
-            kind: symbolKindFor(element),
-          ));
+          globalExternalSymbols.add(
+            SymbolInformation(
+              symbol: symbol,
+              documentation: meta.documentation,
+              signatureDocumentation: meta.signatureDocumentation,
+              kind: symbolKindFor(element),
+            ),
+          );
         }
       }
     }
@@ -165,22 +164,29 @@ class ScipVisitor extends GeneralizingAstVisitor {
     final symbol = _symbolGenerator.symbolFor(element);
     if (symbol == null) return null;
 
-    final meta =
-        getSymbolMetadata(element, element.nameOffset, _analysisErrors);
-    symbols.add(SymbolInformation(
-      symbol: symbol,
-      documentation: meta.documentation,
-      relationships: relationships,
-      signatureDocumentation: meta.signatureDocumentation,
-      kind: symbolKindFor(element),
-    ));
+    final meta = getSymbolMetadata(
+      element,
+      element.nameOffset,
+      _analysisErrors,
+    );
+    symbols.add(
+      SymbolInformation(
+        symbol: symbol,
+        documentation: meta.documentation,
+        relationships: relationships,
+        signatureDocumentation: meta.signatureDocumentation,
+        kind: symbolKindFor(element),
+      ),
+    );
 
-    occurrences.add(Occurrence(
-      range: _lineInfo.getRange(element.nameOffset, element.nameLength),
-      symbol: symbol,
-      symbolRoles: SymbolRole.Definition.value,
-      diagnostics: meta.diagnostics,
-      enclosingRange: _lineInfo.getRange(node.offset, node.length),
-    ));
+    occurrences.add(
+      Occurrence(
+        range: _lineInfo.getRange(element.nameOffset, element.nameLength),
+        symbol: symbol,
+        symbolRoles: SymbolRole.Definition.value,
+        diagnostics: meta.diagnostics,
+        enclosingRange: _lineInfo.getRange(node.offset, node.length),
+      ),
+    );
   }
 }

--- a/lib/src/symbol_generator.dart
+++ b/lib/src/symbol_generator.dart
@@ -33,8 +33,8 @@ class SymbolGenerator {
       // typedef, or a function as a parameter), we don't want to index it
       // as a definition (nothing is defined, just referenced). Return false
       // and let the [_visitSimpleIdentifier] declare the reference
-      final parentParameter =
-          node.parent?.thisOrAncestorOfType<GenericFunctionType>();
+      final parentParameter = node.parent
+          ?.thisOrAncestorOfType<GenericFunctionType>();
       if (parentParameter != null) return null;
 
       var element = node.declaredElement;
@@ -57,8 +57,8 @@ class SymbolGenerator {
         // ConstructorNames can also include an import PrefixIdentifier: `math.Rectangle()`
         // both 'math' and 'Rectangle' are SimpleIdentifiers. We only want the constructor
         // element for 'Rectangle' in this case
-        final parentPrefixIdentifier =
-            node.thisOrAncestorOfType<PrefixedIdentifier>();
+        final parentPrefixIdentifier = node
+            .thisOrAncestorOfType<PrefixedIdentifier>();
         if (parentPrefixIdentifier?.prefix == node) return element;
 
         // Constructors can be named: `Foo.bar()`, both `Foo` and `bar` are SimpleIdentifiers
@@ -81,7 +81,8 @@ class SymbolGenerator {
         if ([
           FunctionElement.LOAD_LIBRARY_NAME,
           FunctionElement.CALL_METHOD_NAME,
-        ].contains(element.name)) return null;
+        ].contains(element.name))
+          return null;
       }
 
       // [element] for assignment fields is null. If the parent node
@@ -89,8 +90,8 @@ class SymbolGenerator {
       // to an assignment line. In that case, use the read/write element attached
       // to this node instead of the [node]'s element
       if (element == null) {
-        final assignmentExpr =
-            node.thisOrAncestorOfType<CompoundAssignmentExpression>();
+        final assignmentExpr = node
+            .thisOrAncestorOfType<CompoundAssignmentExpression>();
         if (assignmentExpr == null) return null;
 
         element = assignmentExpr.readElement ?? assignmentExpr.writeElement;
@@ -117,8 +118,10 @@ class SymbolGenerator {
       return element;
     }
 
-    display('WARN: Received unknown ast node type in elementFor: '
-        '${node.runtimeType} ($node). Skipping');
+    display(
+      'WARN: Received unknown ast node type in elementFor: '
+      '${node.runtimeType} ($node). Skipping',
+    );
 
     return null;
   }
@@ -145,11 +148,7 @@ class SymbolGenerator {
     if (descriptor == null) return null;
 
     // Symbol Form: '<scheme> ' ' <package> ' ' (<descriptor>)+ | 'local ' <local-id>'
-    return [
-      'scip-dart',
-      _getPackage(element),
-      descriptor,
-    ].join(' ');
+    return ['scip-dart', _getPackage(element), descriptor].join(' ');
   }
 
   String fileSymbolFor(String path) {
@@ -176,21 +175,23 @@ class SymbolGenerator {
     // and name must be handled custom
     if (_isInSdk(element)) {
       final packageName = _pathForSdkElement(element).split('/').first;
-      final packageVersion =
-          element.library!.languageVersion.package.toString();
+      final packageVersion = element.library!.languageVersion.package
+          .toString();
       return 'pub $packageName $packageVersion';
     }
 
-    final package =
-        _packageConfig.packageOf(Uri.file(element.source!.fullName));
+    final package = _packageConfig.packageOf(
+      Uri.file(element.source!.fullName),
+    );
     if (package == null) {
       // this should only happen if the source references a package that is not defined
       // in the pubspec (as a main or transitive dep)
       throw Exception('Unable to find package within packageConfig');
     }
 
-    final packageVersion =
-        PackageVersionCache.versionFor(package.root.toFilePath());
+    final packageVersion = PackageVersionCache.versionFor(
+      package.root.toFilePath(),
+    );
     return 'pub ${package.name} $packageVersion';
   }
 
@@ -231,7 +232,8 @@ class SymbolGenerator {
       final config = _packageConfig.packageOf(Uri.file(sourcePath));
       if (config == null) {
         throw Exception(
-            'Could not find package for $sourcePath. Have you run pub get?');
+          'Could not find package for $sourcePath. Have you run pub get?',
+        );
       }
 
       filePath = sourcePath.substring(config.root.toFilePath().length);
@@ -246,8 +248,9 @@ class SymbolGenerator {
 
     if (element is ConstructorElement) {
       final className = element.enclosingElement.name;
-      final constructorName =
-          element.name.isNotEmpty ? element.name : '`<constructor>`';
+      final constructorName = element.name.isNotEmpty
+          ? element.name
+          : '`<constructor>`';
       return '$namespace/$className#$constructorName().';
     }
 
@@ -342,7 +345,8 @@ class SymbolGenerator {
       return element.enclosingElement!.source!.uri.toString();
     } else {
       throw Exception(
-          'Unable to find path to dart sdk element: ${element.source!.fullName}');
+        'Unable to find path to dart sdk element: ${element.source!.fullName}',
+      );
     }
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -16,11 +16,7 @@ Future<List<String>> pubspecPathsFor(String rootDirectory) async {
       .toList();
 }
 
-enum DisplayLevel {
-  info,
-  warn,
-  error,
-}
+enum DisplayLevel { info, warn, error }
 
 void display(String input, {DisplayLevel level = DisplayLevel.warn}) {
   if (!Flags.instance.verbose) return;
@@ -72,18 +68,22 @@ String? getYamlSection(
   final sectionKeyIndentSize =
       sectionKeyLine.length - sectionKeyLine.trimLeft().length;
 
-  final inSectionIndent =
-      List.filled(sectionKeyIndentSize + indentSize, ' ').join();
+  final inSectionIndent = List.filled(
+    sectionKeyIndentSize + indentSize,
+    ' ',
+  ).join();
 
   final inSectionLines = sectionAndAfterLines
       .skip(1) // skip the section key line
       .takeWhile(
-          (line) => line.trim().isEmpty || line.startsWith(inSectionIndent))
+        (line) => line.trim().isEmpty || line.startsWith(inSectionIndent),
+      )
       .toList();
 
-  return [if (!skipMatchedLine) sectionKeyLine, ...inSectionLines]
-      .where((line) => line.trim().isNotEmpty)
-      .join('\n');
+  return [
+    if (!skipMatchedLine) sectionKeyLine,
+    ...inSectionLines,
+  ].where((line) => line.trim().isNotEmpty).join('\n');
 }
 
 int getYamlIndentSize(String str) {

--- a/tool/ast_printer.dart
+++ b/tool/ast_printer.dart
@@ -26,10 +26,7 @@ Future<void> main(List<String> args) async {
       .toList();
 
   final collection = AnalysisContextCollection(
-    includedPaths: [
-      ...allPackageRoots,
-      dirPath,
-    ],
+    includedPaths: [...allPackageRoots, dirPath],
   );
 
   final context = collection.contextFor(dirPath);
@@ -55,7 +52,8 @@ class AstPrinter extends GeneralizingAstVisitor {
   void visitNode(AstNode node) {
     final indentStr = List.filled(indent, '    ').join('');
     print(
-        '$indentStr${chalk.green(node.toString())} ${chalk.faint(node.runtimeType.toString())}');
+      '$indentStr${chalk.green(node.toString())} ${chalk.faint(node.runtimeType.toString())}',
+    );
 
     indent++;
     super.visitNode(node);

--- a/tool/dart_dev/config.dart
+++ b/tool/dart_dev/config.dart
@@ -4,8 +4,5 @@ import 'package:glob/glob.dart';
 final config = {
   ...coreConfig,
   'format': FormatTool()
-    ..exclude = [
-      Glob('snapshots/**'),
-      Glob('lib/src/gen/*.dart'),
-    ],
+    ..exclude = [Glob('snapshots/**'), Glob('lib/src/gen/*.dart')],
 };


### PR DESCRIPTION
Now that the repo is upgraded to Dart 3, we can re-enable the format check in CI and reformat all the Dart code. 

Look for and remove
`enable-format-check: false`

Run the formatter with one of these commands depending on what the repo uses:
`dart run dart_dev format`
`dart format .`

AC:
The format check should run and pass in CI.