### PR TITLE
Bump fedx-ghas to setup-creds v3 versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,12 +13,12 @@ permissions:
 
 jobs:
   checks:
-    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.14
+    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v3.0.1
     with:
       sdk: 3.12.2
 
   build:
-    uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.14
+    uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v3.0.1
     with:
       sdk: 3.12.2
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,4 +13,4 @@ permissions:
 jobs:
   # Generates and uploads sbom, and publishes to pub.dev
   publish:
-    uses: Workiva/gha-dart-oss/.github/workflows/publish.yaml@v0.1.14
+    uses: Workiva/gha-dart-oss/.github/workflows/publish.yaml@v3.0.1


### PR DESCRIPTION
## Problem
This PR bumps fedx's ghas (ts, dart, utils, semver-audit, and scip) to the versions that use gha-setup-credentials v3

## QA
- [ ] CI passes

[_Created by Sourcegraph batch change `matthewnitschke-lvmfc/fedx-gha-bumps`._](https://workiva.sourcegraphcloud.com/users/matthewnitschke-lvmfc/batch-changes/fedx-gha-bumps)